### PR TITLE
Retain boolean and remove "DEFERRABLE INITIALLY DEFERRED"

### DIFF
--- a/sqlite3-to-mysql.py
+++ b/sqlite3-to-mysql.py
@@ -16,9 +16,6 @@ def _replace(line):
         return
 #    line = line.replace("INTEGER PRIMARY KEY", "INTEGER PRIMARY KEY")
     line = line.replace("AUTOINCREMENT", "AUTO_INCREMENT")
-    line = line.replace("boolean", "integer")
-    line = line.replace("boolean DEFAULT 't'", "integer DEFAULT 1")
-    line = line.replace("boolean DEFAULT 'f'", "integer DEFAULT 0")
     line = line.replace("DEFAULT 't'", "DEFAULT 1")
     line = line.replace("DEFAULT 'f'", "DEFAULT 0")
     line = line.replace(",'t'", ",1")

--- a/sqlite3-to-mysql.py
+++ b/sqlite3-to-mysql.py
@@ -21,6 +21,7 @@ def _replace(line):
     line = line.replace(",'t'", ",1")
     line = line.replace(",'f'", ",0")
     line = line.replace("COLLATE NOCASE_UTF8", "")
+    line = line.replace("DEFERRABLE INITIALLY DEFERRED", "")
     line = line.replace("integer DEFAULT 0 NOT NULL", "integer NOT NULL DEFAULT 0")
     line = line.replace("integer DEFAULT 1 NOT NULL", "integer NOT NULL DEFAULT 1")
     line = line.replace("varchar ", "varchar(255) ")


### PR DESCRIPTION
Currently, boolean is also supported in MySQL as an alias for tinyint, so one of the commits keeps it.

The other commit removes "DEFERRABLE INITIALLY DEFERRED" which does not exist in MySQL.
In my case I could import the dump to MySQL after removing it.